### PR TITLE
Handle sql output

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from flask_restful import Resource, reqparse, Api
 from flask_cors import CORS
 from step_2 import step_2_main
 from db_interface import test_select
+from querybuilder import build_query
 
 app = Flask(__name__)
 CORS(app)
@@ -70,8 +71,14 @@ class Email_Data(Resource):
 
     def post(self):
         args = Email_Data.parser.parse_args()
-        step_2_main("step_1_folder/simple_raw_data.plk", args['filter_dict'], args['recipient_email'])
-        return {'output': "sent!"}
+        # step_2_main("step_1_folder/simple_raw_data.plk", args['filter_dict'], args['recipient_email'])
+        
+        # build query
+        tablename = "codetran_collegedata.collegescorecard"
+        select_col = ["school_name"]
+        query = build_query(tablename, select_col, args['filter_dict'])
+
+        return {'output': "sent!", "query": query}
 
 
 class All_Movies(Resource):

--- a/db_interface.py
+++ b/db_interface.py
@@ -32,3 +32,40 @@ def test_select():
 
     print("returned list", l)
     return l
+
+
+def execute_query(q):
+    conn.query(q)
+    result = conn.store_result()
+
+    # l  = []
+    # for i in range(result.num_rows()):
+    #     l.append(result.fetch_row())
+
+    # l = result.fetch_row(maxrows=0, how=1)
+
+    # print("returned list", l)
+    return result
+
+
+# {'school_name': 'Columbia University in the City of New York', 'latest_student_size': Decimal('8216.0')}
+
+def query_to_dict_of_lists(q):
+    result = execute_query(q)
+
+    return result.fetch_row(maxrows=0, how=1)
+
+
+
+
+
+
+
+
+
+
+# execute_query("""SELECT * FROM james_table""")
+# execute_query("SELECT * FROM james_table")
+# execute_query("SELECT school_name, latest_student_size FROM codetran_collegedata.collegescorecard WHERE latest_admissions_act_scores_midpoint_cumulative BETWEEN 32 AND 36 AND latest_student_size BETWEEN 0 AND 50000")
+query_to_dict_of_lists("SELECT school_name, latest_student_size FROM codetran_collegedata.collegescorecard WHERE latest_admissions_act_scores_midpoint_cumulative BETWEEN 32 AND 36 AND latest_student_size BETWEEN 0 AND 50000")
+# test_select()

--- a/db_interface.py
+++ b/db_interface.py
@@ -6,13 +6,11 @@ import os
 from MySQLdb.constants import FIELD_TYPE
 
 
-
 host = '162.241.230.118'
 user = os.environ['MYSQL_USER']
 password = os.environ['MYSQL_PASSWORD']
 port = 3306
 db = 'codetran_collegedata'
-
 my_conv = { FIELD_TYPE.LONG: int, FIELD_TYPE.DECIMAL: int}
 
 conn = MySQLdb.Connection(
@@ -24,48 +22,12 @@ conn = MySQLdb.Connection(
     db=db
 )
 
-
-
-# conn=_mysql.connect(
-#     conv = my_conv,
-#     host=host,
-#     user=user,
-#     passwd=password,
-#     port=port,
-#     db=db
-# )
-
-
-def test_select():
-    print("test select started")
-
-    # Example of how to fetch table data:
-    conn.query("""SELECT * FROM james_table""")
-    result = conn.store_result()
-
-    l  = []
-    for i in range(result.num_rows()):
-        l.append(result.fetch_row())
-
-    print("returned list", l)
-    return l
-
-
 def execute_query(q):
     conn.query(q)
     result = conn.store_result()
 
-    # l  = []
-    # for i in range(result.num_rows()):
-    #     l.append(result.fetch_row())
-
-    # l = result.fetch_row(maxrows=0, how=1)
-
-    # print("returned list", l)
     return result
 
-
-# {'school_name': 'Columbia University in the City of New York', 'latest_student_size': Decimal('8216.0')}
 
 def query_to_json(q):
     result = execute_query(q)
@@ -88,16 +50,3 @@ def query_to_json(q):
     return out
 
 
-
-
-
-
-
-
-
-
-# execute_query("""SELECT * FROM james_table""")
-# execute_query("SELECT * FROM james_table")
-# execute_query("SELECT school_name, latest_student_size FROM codetran_collegedata.collegescorecard WHERE latest_admissions_act_scores_midpoint_cumulative BETWEEN 32 AND 36 AND latest_student_size BETWEEN 0 AND 50000")
-query_to_json("SELECT school_name, latest_student_size FROM codetran_collegedata.collegescorecard WHERE latest_admissions_act_scores_midpoint_cumulative BETWEEN 34 AND 30 AND latest_student_size BETWEEN 0 AND 50000")
-# test_select()

--- a/db_interface.py
+++ b/db_interface.py
@@ -52,13 +52,13 @@ def execute_query(q):
 
 def query_to_json(q):
     result = execute_query(q)
-    result_temp = result
-
     first_row = result.fetch_row(how=1)
+
+    # if query doesn't return anything, return object with empty lists
     if len(first_row) == 0:
         return {"column_names": [], "data": []}
 
-    # column names are grabbed from first row TODO: catch error if no data is returned
+    # column names are grabbed from first row
     out = {
         "column_names": list(first_row[0].keys()),
         "data": [tuple(first_row[0].values())]  

--- a/db_interface.py
+++ b/db_interface.py
@@ -50,10 +50,25 @@ def execute_query(q):
 
 # {'school_name': 'Columbia University in the City of New York', 'latest_student_size': Decimal('8216.0')}
 
-def query_to_dict_of_lists(q):
+def query_to_json(q):
     result = execute_query(q)
+    result_temp = result
 
-    return result.fetch_row(maxrows=0, how=1)
+    first_row = result.fetch_row(how=1)
+    if len(first_row) == 0:
+        return {"column_names": [], "data": []}
+
+    # column names are grabbed from first row TODO: catch error if no data is returned
+    out = {
+        "column_names": list(first_row[0].keys()),
+        "data": [tuple(first_row[0].values())]  
+        }
+
+    # add the rest of the rows to data
+    l = result.fetch_row(maxrows=0, how=0)
+    out["data"].extend(l)
+
+    return out
 
 
 
@@ -67,5 +82,5 @@ def query_to_dict_of_lists(q):
 # execute_query("""SELECT * FROM james_table""")
 # execute_query("SELECT * FROM james_table")
 # execute_query("SELECT school_name, latest_student_size FROM codetran_collegedata.collegescorecard WHERE latest_admissions_act_scores_midpoint_cumulative BETWEEN 32 AND 36 AND latest_student_size BETWEEN 0 AND 50000")
-query_to_dict_of_lists("SELECT school_name, latest_student_size FROM codetran_collegedata.collegescorecard WHERE latest_admissions_act_scores_midpoint_cumulative BETWEEN 32 AND 36 AND latest_student_size BETWEEN 0 AND 50000")
+query_to_json("SELECT school_name, latest_student_size FROM codetran_collegedata.collegescorecard WHERE latest_admissions_act_scores_midpoint_cumulative BETWEEN 34 AND 30 AND latest_student_size BETWEEN 0 AND 50000")
 # test_select()

--- a/db_interface.py
+++ b/db_interface.py
@@ -1,7 +1,10 @@
 from dotenv import load_dotenv
 load_dotenv()
 import MySQLdb
+from MySQLdb import _mysql
 import os
+from MySQLdb.constants import FIELD_TYPE
+
 
 
 host = '162.241.230.118'
@@ -10,13 +13,27 @@ password = os.environ['MYSQL_PASSWORD']
 port = 3306
 db = 'codetran_collegedata'
 
+my_conv = { FIELD_TYPE.LONG: int, FIELD_TYPE.DECIMAL: int}
+
 conn = MySQLdb.Connection(
+    conv = my_conv, # FIXME: this does not seem to be working yet TAIGA#10
     host=host,
     user=user,
     passwd=password,
     port=port,
     db=db
 )
+
+
+
+# conn=_mysql.connect(
+#     conv = my_conv,
+#     host=host,
+#     user=user,
+#     passwd=password,
+#     port=port,
+#     db=db
+# )
 
 
 def test_select():

--- a/test_db_interface.py
+++ b/test_db_interface.py
@@ -1,0 +1,53 @@
+import unittest2
+from db_interface import query_to_json
+
+
+class TestDb_Interface(unittest2.TestCase):
+
+    def test_no_results(self):
+        q = "SELECT school_name FROM codetran_collegedata.collegescorecard WHERE latest_admissions_act_scores_midpoint_cumulative BETWEEN 36 AND 35"
+
+        actualOutput = query_to_json(q)
+        expectedOutput = {"column_names": [], "data": []}
+
+        self.assertEqual(actualOutput, expectedOutput)
+
+    def  test_one_col_results(self):
+        q = 'SELECT school_name FROM codetran_collegedata.collegescorecard WHERE school_name="Pomona College" or school_name="Rice University"'
+
+        actualOutput = query_to_json(q)
+        expectedOutput = {
+            "column_names": ["school_name"],
+             "data": [("Pomona College",), ("Rice University",)]
+        }
+
+        self.assertEqual(actualOutput["column_names"], expectedOutput["column_names"])
+        self.assertEqual(actualOutput["data"], expectedOutput["data"])
+
+    def test_two_col_results(self):
+        q = 'SELECT school_name, school_state FROM codetran_collegedata.collegescorecard WHERE school_name="Pomona College" or school_name="Rice University"'
+
+        actualOutput = query_to_json(q)
+        expectedOutput = {
+            "column_names": ["school_name", "school_state"],
+             "data": [("Pomona College", "CA"), ("Rice University", "TX")]
+        }
+
+        self.assertEqual(actualOutput["column_names"], expectedOutput["column_names"])
+        self.assertEqual(actualOutput["data"], expectedOutput["data"])
+
+    def test_non_string_results(self):
+        q = 'SELECT school_name, latest_student_size FROM codetran_collegedata.collegescorecard WHERE school_name = "Pomona College" OR school_name = "Rice University"'
+
+        actualOutput = query_to_json(q)
+        expectedOutput = {
+            "column_names": ["school_name", "latest_student_size"],
+             "data": [("Pomona College", "CA"), ("Rice University", "TX")]
+        }
+
+        self.assertEqual(actualOutput["column_names"], expectedOutput["column_names"])
+        self.assertEqual(actualOutput["data"], expectedOutput["data"])
+
+
+if __name__ == '__main__':
+    unittest2.main()

--- a/test_db_interface.py
+++ b/test_db_interface.py
@@ -42,7 +42,7 @@ class TestDb_Interface(unittest2.TestCase):
         actualOutput = query_to_json(q)
         expectedOutput = {
             "column_names": ["school_name", "latest_student_size"],
-             "data": [("Pomona College", "CA"), ("Rice University", "TX")]
+             "data": [("Pomona College", 1549.0), ("Rice University", 3962.0)]
         }
 
         self.assertEqual(actualOutput["column_names"], expectedOutput["column_names"])

--- a/test_querybuilder.py
+++ b/test_querybuilder.py
@@ -1,7 +1,7 @@
 import unittest2
 import querybuilder as qb
 
-class TestLogStatement(unittest2.TestCase):
+class TestQueryBuilder(unittest2.TestCase):
 
     def test_empty(self):
         tablename = "myTable"


### PR DESCRIPTION
### The problem:
- Frontend [Material UI Table Components](https://material-ui.com/components/tables/) need lists of lists to display data
- mySQL does not return results in the format required by the frontend

### The solution:
Build an _interface_ to convert mySQL results to material UI table compatible results.

### Example
#### mySQL Query:
```
SELECT school_name, school_state 
FROM codetran_collegedata.collegescorecard 
WHERE school_name="Pomona College" or school_name="Rice University"
```
#### Correctly Formatted output
```
{
            "column_names": ["school_name", "school_state"],
             "data": [("Pomona College", "CA"), ("Rice University", "TX")]
}
```