### PR TITLE
Fix SQL Connection and queryBuilder problem

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,17 +3,9 @@ from flask import Flask
 from flask_restful import Resource, reqparse, Api
 from flask_cors import CORS
 
-# mysql related imports
-import MySQLdb
-from MySQLdb.constants import FIELD_TYPE
-from dotenv import load_dotenv
-load_dotenv()  # loads in .env variables
-import os
-
 # other imports
 from querybuilder import build_query
 from db_interface import query_to_json
-
 
 # Start flask app
 app = Flask(__name__)
@@ -21,15 +13,6 @@ CORS(app)
 api = Api(app)
 app.config[
     'PROPAGATE_EXCEPTIONS'] = True  # TODO: figure out if this is what I want
-
-# set up sql connection
-conn = MySQLdb.Connection(
-    conv={FIELD_TYPE.LONG: int, FIELD_TYPE.DECIMAL: int},  # FIXME: this does not seem to be working yet TAIGA#10
-    host='162.241.230.118',
-    user=os.environ['MYSQL_USER'],
-    passwd=os.environ['MYSQL_PASSWORD'],
-    port=3306,
-    db='codetran_collegedata')
 
 
 class College_Data(Resource):
@@ -46,7 +29,7 @@ class College_Data(Resource):
     def get(self):
         # make a call for one row of data in order to extract column names
         q = 'SELECT * FROM codetran_collegedata.collegescorecard WHERE school_name="Pomona College"'
-        column_names = query_to_json(q, sql_connection=conn)['column_names']
+        column_names = query_to_json(q)['column_names']
 
         return {
             'class': 'Email_Data',
@@ -61,7 +44,7 @@ class College_Data(Resource):
         tablename = "codetran_collegedata.collegescorecard"
         select_col = ["school_name", "school_state"]
         q = build_query(tablename, select_col, args['filter_dict'])
-        return {"table": query_to_json(q, sql_connection=conn)}
+        return {"table": query_to_json(q)}
 
 
 class Test(Resource):

--- a/db_interface.py
+++ b/db_interface.py
@@ -5,10 +5,14 @@ from dotenv import load_dotenv
 load_dotenv()  # loads in .env variables
 import os
 
+
 def execute_query(q):
     # set up sql connection
     conn = MySQLdb.Connection(
-        conv={FIELD_TYPE.LONG: int, FIELD_TYPE.DECIMAL: int},  # FIXME: this does not seem to be working yet TAIGA#10
+        conv={
+            FIELD_TYPE.LONG: int,
+            FIELD_TYPE.DECIMAL: int
+        },  # FIXME: this does not seem to be working yet TAIGA#10
         host='162.241.230.118',
         user=os.environ['MYSQL_USER'],
         passwd=os.environ['MYSQL_PASSWORD'],

--- a/db_interface.py
+++ b/db_interface.py
@@ -1,12 +1,28 @@
-def execute_query(q, sql_connection):
-    sql_connection.query(q)
-    result = sql_connection.store_result()
+# mysql related imports
+import MySQLdb
+from MySQLdb.constants import FIELD_TYPE
+from dotenv import load_dotenv
+load_dotenv()  # loads in .env variables
+import os
+
+def execute_query(q):
+    # set up sql connection
+    conn = MySQLdb.Connection(
+        conv={FIELD_TYPE.LONG: int, FIELD_TYPE.DECIMAL: int},  # FIXME: this does not seem to be working yet TAIGA#10
+        host='162.241.230.118',
+        user=os.environ['MYSQL_USER'],
+        passwd=os.environ['MYSQL_PASSWORD'],
+        port=3306,
+        db='codetran_collegedata')
+
+    conn.query(q)
+    result = conn.store_result()
 
     return result
 
 
-def query_to_json(q, sql_connection):
-    result = execute_query(q, sql_connection)
+def query_to_json(q):
+    result = execute_query(q)
     first_row = result.fetch_row(how=1)
 
     # if query doesn't return anything, return object with empty lists

--- a/db_interface.py
+++ b/db_interface.py
@@ -1,35 +1,12 @@
-from dotenv import load_dotenv
-load_dotenv()
-import MySQLdb
-from MySQLdb import _mysql
-import os
-from MySQLdb.constants import FIELD_TYPE
-
-host = '162.241.230.118'
-user = os.environ['MYSQL_USER']
-password = os.environ['MYSQL_PASSWORD']
-port = 3306
-db = 'codetran_collegedata'
-my_conv = {FIELD_TYPE.LONG: int, FIELD_TYPE.DECIMAL: int}
-
-conn = MySQLdb.Connection(
-    conv=my_conv,  # FIXME: this does not seem to be working yet TAIGA#10
-    host=host,
-    user=user,
-    passwd=password,
-    port=port,
-    db=db)
-
-
-def execute_query(q):
-    conn.query(q)
-    result = conn.store_result()
+def execute_query(q, sql_connection):
+    sql_connection.query(q)
+    result = sql_connection.store_result()
 
     return result
 
 
-def query_to_json(q):
-    result = execute_query(q)
+def query_to_json(q, sql_connection):
+    result = execute_query(q, sql_connection)
     first_row = result.fetch_row(how=1)
 
     # if query doesn't return anything, return object with empty lists

--- a/querybuilder.py
+++ b/querybuilder.py
@@ -49,7 +49,7 @@ def build_query(tablename, select_cols, filter_dict):
     in_dict = filter_dict["is_in"]
     for k in in_dict.keys():
         options = in_dict[k]  # list of options that row value must be in
-        if len(options)>0:
+        if len(options) > 0:
             col = k.replace(".", "_")
             options = '"' + '", "'.join(
                 options) + '"'  #  make options into string (SQL format)

--- a/querybuilder.py
+++ b/querybuilder.py
@@ -48,12 +48,13 @@ def build_query(tablename, select_cols, filter_dict):
     # WHERE IN
     in_dict = filter_dict["is_in"]
     for k in in_dict.keys():
-        col = k.replace(".", "_")
         options = in_dict[k]  # list of options that row value must be in
-        options = '"' + '", "'.join(
-            options) + '"'  #  make options into string (SQL format)
-        condition = col + " IN (" + options + ")"
-        where_list.append(condition)
+        if len(options)>0:
+            col = k.replace(".", "_")
+            options = '"' + '", "'.join(
+                options) + '"'  #  make options into string (SQL format)
+            condition = col + " IN (" + options + ")"
+            where_list.append(condition)
 
     # Put everything together
     query = select_str + " " + from_str

--- a/test_querybuilder.py
+++ b/test_querybuilder.py
@@ -24,13 +24,20 @@ class TestQueryBuilder(unittest2.TestCase):
 
         self.assertEqual(actualSQL, expectedSQL)
 
-
     def test_nested_empty_in(self):
         tablename = "myTable"
         select_cols = ["school_name"]
         filter_dict = {
-            "is_in":{"school.region_id":[],"school.ownership":[],"school.degrees_awarded.highest":[],"school.institutional_characteristics.level":[],"school.minority_serving.historically_black":[],"singlesex.or.coed":[]},
-            "is_btwn": {}}
+            "is_in": {
+                "school.region_id": [],
+                "school.ownership": [],
+                "school.degrees_awarded.highest": [],
+                "school.institutional_characteristics.level": [],
+                "school.minority_serving.historically_black": [],
+                "singlesex.or.coed": []
+            },
+            "is_btwn": {}
+        }
 
         actualSQL = qb.build_query(tablename, select_cols, filter_dict)
         expectedSQL = "SELECT school_name FROM myTable"
@@ -41,8 +48,16 @@ class TestQueryBuilder(unittest2.TestCase):
         tablename = "myTable"
         select_cols = ["school_name"]
         filter_dict = {
-            "is_in":{"school.region_id":[],"school.ownership":["Private nonprofit"],"school.degrees_awarded.highest":[],"school.institutional_characteristics.level":[],"school.minority_serving.historically_black":[],"singlesex.or.coed":[]},
-            "is_btwn": {}}
+            "is_in": {
+                "school.region_id": [],
+                "school.ownership": ["Private nonprofit"],
+                "school.degrees_awarded.highest": [],
+                "school.institutional_characteristics.level": [],
+                "school.minority_serving.historically_black": [],
+                "singlesex.or.coed": []
+            },
+            "is_btwn": {}
+        }
 
         actualSQL = qb.build_query(tablename, select_cols, filter_dict)
         expectedSQL = 'SELECT school_name FROM myTable WHERE school_ownership IN ("Private nonprofit")'
@@ -53,8 +68,22 @@ class TestQueryBuilder(unittest2.TestCase):
         tablename = "myTable"
         select_cols = ["school_name"]
         filter_dict = {
-            "is_in":{"school.region_id":[],"school.ownership":["Private nonprofit"],"school.degrees_awarded.highest":[],"school.institutional_characteristics.level":[],"school.minority_serving.historically_black":[],"singlesex.or.coed":[]},
-            "is_btwn": {"latest.student.size": {"min": 0, "max": 50000, "inclusive": "true"}}}
+            "is_in": {
+                "school.region_id": [],
+                "school.ownership": ["Private nonprofit"],
+                "school.degrees_awarded.highest": [],
+                "school.institutional_characteristics.level": [],
+                "school.minority_serving.historically_black": [],
+                "singlesex.or.coed": []
+            },
+            "is_btwn": {
+                "latest.student.size": {
+                    "min": 0,
+                    "max": 50000,
+                    "inclusive": "true"
+                }
+            }
+        }
 
         actualSQL = qb.build_query(tablename, select_cols, filter_dict)
         expectedSQL = 'SELECT school_name FROM myTable WHERE latest_student_size BETWEEN 0 AND 50000 AND school_ownership IN ("Private nonprofit")'

--- a/test_querybuilder.py
+++ b/test_querybuilder.py
@@ -14,13 +14,50 @@ class TestQueryBuilder(unittest2.TestCase):
 
         self.assertEqual(actualSQL, expectedSQL)
 
-    def test_multiple_select(self):
+    def test_empty_multiple_select(self):
         tablename = "myTable"
         select_cols = ["school_name", "midpoint.act.score"]
         filter_dict = {"is_in": {}, "is_btwn": {}}
 
         actualSQL = qb.build_query(tablename, select_cols, filter_dict)
         expectedSQL = "SELECT school_name, midpoint_act_score FROM myTable"
+
+        self.assertEqual(actualSQL, expectedSQL)
+
+
+    def test_nested_empty_in(self):
+        tablename = "myTable"
+        select_cols = ["school_name"]
+        filter_dict = {
+            "is_in":{"school.region_id":[],"school.ownership":[],"school.degrees_awarded.highest":[],"school.institutional_characteristics.level":[],"school.minority_serving.historically_black":[],"singlesex.or.coed":[]},
+            "is_btwn": {}}
+
+        actualSQL = qb.build_query(tablename, select_cols, filter_dict)
+        expectedSQL = "SELECT school_name FROM myTable"
+
+        self.assertEqual(actualSQL, expectedSQL)
+
+    def test_nested_empty_in_with_nonempty_in(self):
+        tablename = "myTable"
+        select_cols = ["school_name"]
+        filter_dict = {
+            "is_in":{"school.region_id":[],"school.ownership":["Private nonprofit"],"school.degrees_awarded.highest":[],"school.institutional_characteristics.level":[],"school.minority_serving.historically_black":[],"singlesex.or.coed":[]},
+            "is_btwn": {}}
+
+        actualSQL = qb.build_query(tablename, select_cols, filter_dict)
+        expectedSQL = 'SELECT school_name FROM myTable WHERE school_ownership IN ("Private nonprofit")'
+
+        self.assertEqual(actualSQL, expectedSQL)
+
+    def test_nested_empty_in_with_nonempty_in_and_nonempty_btwn(self):
+        tablename = "myTable"
+        select_cols = ["school_name"]
+        filter_dict = {
+            "is_in":{"school.region_id":[],"school.ownership":["Private nonprofit"],"school.degrees_awarded.highest":[],"school.institutional_characteristics.level":[],"school.minority_serving.historically_black":[],"singlesex.or.coed":[]},
+            "is_btwn": {"latest.student.size": {"min": 0, "max": 50000, "inclusive": "true"}}}
+
+        actualSQL = qb.build_query(tablename, select_cols, filter_dict)
+        expectedSQL = 'SELECT school_name FROM myTable WHERE latest_student_size BETWEEN 0 AND 50000 AND school_ownership IN ("Private nonprofit")'
 
         self.assertEqual(actualSQL, expectedSQL)
 


### PR DESCRIPTION
## SQL Connection
- after a couple of minutes of inactivity, the heroku backend would throw a "SQL Server is away" exception
- To fix this, I reconnected to the server every time a query was executed. This seemed to fix it but is not very time efficient and would be great to figure out another solution

## Query Builder Problem
- If `filter_dict[is_in][school.region.id] = []` querybuilder would return `SELECT ... WHERE school_region_id IN ("")`
- This query would return no results of course
- Fixed this by only adding a WHERE condition to query if there was something in the list. The above filter dict will no longer include a WHERE.
