### PR TITLE
changed json output

### DIFF
--- a/db_interface.py
+++ b/db_interface.py
@@ -27,20 +27,17 @@ def execute_query(q):
 
 def query_to_json(q):
     result = execute_query(q)
-    first_row = result.fetch_row(how=1)
+    out = result.fetch_row(how=1, maxrows=0)
 
     # if query doesn't return anything, return object with empty lists
-    if len(first_row) == 0:
+    if len(out) == 0:
         return {"column_names": [], "rows": []}
 
     # column names are grabbed from first row
-    out = {
-        "column_names": list(first_row[0].keys()),
-        "rows": [tuple(first_row[0].values())]
-    }
+    out = {"column_names": list(out[0].keys()), "rows": list(out)}
 
     # add the rest of the rows to data
-    l = result.fetch_row(maxrows=0, how=0)
-    out["rows"].extend(l)
+    # l = result.fetch_row(maxrows=0, how=0)
+    # out["rows"].extend(l)
 
     return out

--- a/test_db_interface.py
+++ b/test_db_interface.py
@@ -18,7 +18,11 @@ class TestDb_Interface(unittest2.TestCase):
         actualOutput = query_to_json(q)
         expectedOutput = {
             "column_names": ["school_name"],
-            "rows": [("Pomona College",), ("Rice University",)]
+            "rows": [{
+                "school_name": "Pomona College"
+            }, {
+                "school_name": "Rice University"
+            }]
         }
 
         self.assertEqual(actualOutput["column_names"],
@@ -31,7 +35,34 @@ class TestDb_Interface(unittest2.TestCase):
         actualOutput = query_to_json(q)
         expectedOutput = {
             "column_names": ["school_name", "school_state"],
-            "rows": [("Pomona College", "CA"), ("Rice University", "TX")]
+            "rows": [{
+                "school_name": "Pomona College",
+                "school_state": "CA"
+            }, {
+                "school_name": "Rice University",
+                "school_state": "TX"
+            }]
+        }
+
+        self.assertEqual(actualOutput["column_names"],
+                         expectedOutput["column_names"])
+        self.assertEqual(actualOutput["rows"], expectedOutput["rows"])
+
+    def test_results_with_id(self):
+        q = 'SELECT ope6_id, school_name, school_state FROM codetran_collegedata.collegescorecard WHERE school_name="Pomona College" or school_name="Rice University"'
+
+        actualOutput = query_to_json(q)
+        expectedOutput = {
+            "column_names": ["ope6_id", "school_name", "school_state"],
+            "rows": [{
+                "ope6_id": 1173,
+                "school_name": "Pomona College",
+                "school_state": "CA"
+            }, {
+                "ope6_id": 3604,
+                "school_name": "Rice University",
+                "school_state": "TX"
+            }]
         }
 
         self.assertEqual(actualOutput["column_names"],


### PR DESCRIPTION
This PR addresses [Taiga Ticket #17](https://tree.taiga.io/project/jackdavidweber-college-data/us/17?no-milestone=1)

### Before:

```
table = {
    {"column_names": ["school_name", "school_state"]},
    {"rows":["Pomona College", "CA"], ["Harvard", "MA"'], ... }
}
```

### After:

```
table = {
    {"column_names": ["school_name", "school_state"]},
    {"rows": [
        {id: 0, school_name: "Pomona College", school_state: "CA"},
        {id:1, school_name: "Harvard", school_state:"MA"}, ...
        ]
    }
}
```