### PR TITLE
redid get request and put all static database references in one file

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@
 from flask import Flask
 from flask_restful import Resource, reqparse, Api
 from flask_cors import CORS
+import sql_info
 
 # other imports
 from querybuilder import build_query
@@ -27,22 +28,15 @@ class College_Data(Resource):
                         help='dictionary with all of filter information')
 
     def get(self):
-        # make a call for one row of data in order to extract column names
-        q = 'SELECT * FROM codetran_collegedata.collegescorecard WHERE school_name="Pomona College"'
-        column_names = query_to_json(q)['column_names']
-
-        return {
-            'class': 'Email_Data',
-            'tablename': "codetran_collegedata.collegescorecard",
-            'column_names': column_names
-        }
+        # provide select columns and filter columns for the frontend to use
+        return sql_info.get_all_info()
 
     def post(self):
         args = College_Data.parser.parse_args()
 
         # build query
-        tablename = "codetran_collegedata.collegescorecard"
-        select_col = ["school_name", "school_state"]
+        tablename = sql_info.get_table_name()
+        select_col = sql_info.get_select_cols()
         q = build_query(tablename, select_col, args['filter_dict'])
         return {"table": query_to_json(q)}
 

--- a/db_interface.py
+++ b/db_interface.py
@@ -1,4 +1,5 @@
 # mysql related imports
+import sql_info
 import MySQLdb
 from MySQLdb.constants import FIELD_TYPE
 from dotenv import load_dotenv
@@ -13,11 +14,11 @@ def execute_query(q):
             FIELD_TYPE.LONG: int,
             FIELD_TYPE.DECIMAL: int
         },  # FIXME: this does not seem to be working yet TAIGA#10
-        host='162.241.230.118',
+        host=sql_info.get_host(),
         user=os.environ['MYSQL_USER'],
         passwd=os.environ['MYSQL_PASSWORD'],
-        port=3306,
-        db='codetran_collegedata')
+        port=sql_info.get_port(),
+        db=sql_info.get_db_name())
 
     conn.query(q)
     result = conn.store_result()

--- a/sql_info.py
+++ b/sql_info.py
@@ -1,0 +1,81 @@
+table_name = "codetran_collegedata.collegescorecard"
+host = '162.241.230.118'
+port = 3306
+db_name = 'codetran_collegedata'
+
+select_cols = ["school_name", "school_state"]
+
+where_cols = {
+    "school.region_id": [
+        'U.S. Service Schools',
+        'New England (CT, ME, MA, NH, RI, VT)',
+        'Mid East (DE, DC, MD, NJ, NY, PA)',
+        'Great Lakes (IL, IN, MI, OH, WI)',
+        'Plains (IA, KS, MN, MO, NE, ND, SD)',
+        'Southeast (AL, AR, FL, GA, KY, LA, MS, NC, SC, TN, VA, WV)',
+        'Southwest (AZ, NM, OK, TX)',
+        'Rocky Mountains (CO, ID, MT, UT, WY)',
+        'Far West (AK, CA, HI, NV, OR, WA)',
+        'Outlying Areas (AS, FM, GU, MH, MP, PR, PW, VI)',
+    ],
+    "school.ownership": [
+        'Public',
+        'Private nonprofit',
+        'Private for-profit',
+    ],
+    "school.degrees_awarded.highest": [
+        'Non-degree-granting',
+        'Certificate degree',
+        'Associate degree',
+        'Bachelors degree',
+        'Graduate degree',
+    ],
+    "school.institutional_characteristics.level": [
+        '4-year',
+        '2-year',
+        'Less-than-2-year',
+    ],
+    "school.minority_serving.historically_black": [
+        'No',
+        'Yes',
+    ],
+    "singlesex.or.coed": [
+        "Single-Sex: Men",
+        "Single-Sex: Women",
+        "Co-Educational",
+    ],
+    "latest.admissions.act_scores.midpoint.cumulative": [0, 36],
+    "latest.student.size": [0, 50000]
+}
+
+
+def get_table_name():
+    return table_name
+
+
+def get_host():
+    return host
+
+
+def get_port():
+    return port
+
+
+def get_db_name():
+    return db_name
+
+
+def get_where_cols():
+    return where_cols
+
+
+def get_select_cols():
+    return select_cols
+
+
+def get_all_info():
+    return {
+        "table_name": table_name,
+        "where_cols": where_cols,
+        "select_cols": select_cols
+    }


### PR DESCRIPTION
### In this PR:
- Removed the static references to database names and columns scattered around the files. Instead, I put all information related to database in one file that can be edited and should eventually pull from the database.
- Updated GET request so that frontend can populate almost everything without static references to database [Ticket#13](https://tree.taiga.io/project/jackdavidweber-college-data/us/13)